### PR TITLE
fix luci.mk path

### DIFF
--- a/themes/luci-theme-rosy/Makefile
+++ b/themes/luci-theme-rosy/Makefile
@@ -9,6 +9,6 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=rosy Theme
 LUCI_DEPENDS:=
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
兼容 luci-theme-* 安装在任意路径的情况

Refer: https://github.com/rosywrt/luci-theme-rosy/pull/8

Refer: https://github.com/coolsnowwolf/lede/commit/72e44c814af00c631aa493c27c275c4684100b18